### PR TITLE
Fixed Mac OS 11.1 bug: Cannot select PNG files. Removed filetype requ…

### DIFF
--- a/magic2gui/callbacks.py
+++ b/magic2gui/callbacks.py
@@ -52,8 +52,7 @@ def open_image(options, env):
         pass
     else:
         # Display a window for chooisng the file
-        filename = fd.askopenfile(filetypes=[("PNG files", "*.png;*.PNG")],
-                                  title="Open "+env+" interferogram")
+        filename = fd.askopenfile(title="Open "+env+" interferogram")
         if filename is not None:
             options.status.set("Reading the file", 0)
             if not options.ncmanual:


### PR DESCRIPTION
Fixed Mac OS 11.1 bug: Cannot select PNG files. Removed filetype requirement in magic2gui/callbacks.py