### PR TITLE
Remove depth, and correct labels to neL

### DIFF
--- a/magic2gui/callbacks.py
+++ b/magic2gui/callbacks.py
@@ -544,7 +544,7 @@ def set_mode(options):
         options.ax.set_ylabel("Distance / $mm$")
         options.cbar = options.fig.colorbar(options.imshow, cax=options.mframe.cax)
         options.mframe.cax.axis('on')
-        options.cbar.ax.set_ylabel('Electron density / $cm^{-3}$', rotation=270, labelpad=20)
+        options.cbar.ax.set_ylabel('Line-Integrated Electron Density, $\int n_e dL$ / $cm^{-2}$', rotation=270, labelpad=20)
     # Clear the view history stack
     options.mframe.clear_nav_stack()
     if options.conserve_limits:
@@ -818,12 +818,12 @@ class PlasmaDialog(m2dialog.Dialog):
         self.e_resolution.grid(row=0, column=1)
         ttk.Label(master, text="pixels per mm").grid(row=0, column=2, sticky=Tk.W)
         # Depth
-        ttk.Label(master, text="Depth of the object:").grid(row=1, sticky=Tk.E)
-        self.e_depth = ttk.Entry(master)
-        if self.options.depth is not None:
-            self.e_depth.insert(0, self.options.depth)
-        self.e_depth.grid(row=1, column=1)
-        ttk.Label(master, text="mm").grid(row=1, column=2, sticky=Tk.W)
+        # ttk.Label(master, text="Depth of the object:").grid(row=1, sticky=Tk.E)
+        # self.e_depth = ttk.Entry(master)
+        # if self.options.depth is not None:
+        #     self.e_depth.insert(0, self.options.depth)
+        # self.e_depth.grid(row=1, column=1)
+        # ttk.Label(master, text="mm").grid(row=1, column=2, sticky=Tk.W)
         # Wavelength
         ttk.Label(master, text="Wavelength:").grid(row=2, sticky=Tk.E)
         self.e_wavelength = ttk.Entry(master)
@@ -844,7 +844,7 @@ class PlasmaDialog(m2dialog.Dialog):
         try:
             # All the inputs should be floats or integers
             float(self.e_resolution.get())
-            float(self.e_depth.get())
+            # float(self.e_depth.get())
             float(self.e_wavelength.get())
             return 1
         except ValueError:
@@ -853,7 +853,8 @@ class PlasmaDialog(m2dialog.Dialog):
 
     def apply(self):
         self.options.resolution = float(self.e_resolution.get())
-        self.options.depth = float(self.e_depth.get())
+        # self.options.depth = float(self.e_depth.get())
+        self.options.depth = 10.0
         self.options.wavelength = float(self.e_wavelength.get())
         self.options.double = self.double_var.get()
         self.result = True

--- a/magic2gui/lineouts.py
+++ b/magic2gui/lineouts.py
@@ -158,7 +158,7 @@ class Lineout():
             self.xspace = sp.linspace(0, len(self.profile)/options.resolution,
                                       len(self.profile))
             self.mframe.ax.set_xlabel("Distance / $mm$")
-            self.mframe.ax.set_ylabel("Electron density / $cm^{-3}$")
+            self.mframe.ax.set_ylabel("Line-Integrated Electron Density $\int n_e dL$ / $cm^{-2}$")
         else:
             self.xspace = sp.linspace(0, len(self.profile), len(self.profile))
             self.mframe.ax.set_xlabel("Distance / $px$")
@@ -258,7 +258,7 @@ class Lineout():
         if filename != '':
             # Add appropriate units to the header
             if self.mode.split("_")[0] == "density":
-                header = "distance (mm),\tplasma density (cm^-3)"
+                header = "distance (mm),\tline-integrated electron density (cm^-2)"
                 scale = self.options.resolution
                 units = "mm"
             else:

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class Options:
         self.cbar = None
         # Shot properties
         self.resolution = None
-        self.depth = None
+        self.depth = 10.0
         self.wavelength = None
         self.double = None
 


### PR DESCRIPTION
Removes the depth option in the "Shot Details" tab, since this should always be set to 10.0, so why not remove the option for the user to accidentally set this as something else.

Also updates the label on the plasma density plot colorbar to specify line-integrated electron density instead.